### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Term/ColorText.pm6
+++ b/lib/Term/ColorText.pm6
@@ -4,7 +4,7 @@ use v6;
 
 use Term::ANSIColor;
 
-module Term::ColorText;
+unit module Term::ColorText;
 
 sub cfmt($color, *@things) {
     my @ar = color($color) X @things;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.